### PR TITLE
0.1.2 - joifulReactForms context props api proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joiful-react-forms",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Automatically generate validated React forms using Joi",
   "main": "lib/index.js",
   "peerDependencies": {

--- a/src/Form.js
+++ b/src/Form.js
@@ -11,6 +11,10 @@ import autobind from 'autobind-decorator'
 
 export default class JoifulForm extends Component {
 
+    static contextTypes = {
+        joifulReactForms: PropTypes.object
+    };
+
     static propTypes = {
         children: PropTypes.node,
         elementTypes: PropTypes.object,
@@ -31,13 +35,14 @@ export default class JoifulForm extends Component {
     static defaultProps = {
         errors: {},
         options: {},
-        values: {},
-        elementTypes: {}
+        values: {}
     };
 
-    constructor(props) {
+    constructor(props, { joifulReactForms: { JoifulInput } }) {
         super(props)
-        this.inputElementTypes = this.getInputElementTypes(this.props.elementTypes)
+        this.inputElementTypes = this.getInputElementTypes(
+            props.elementTypes || (JoifulInput && JoifulInput.types) || {}
+        )
         this.state = this.getStateFromProps(props)
     }
 
@@ -59,9 +64,11 @@ export default class JoifulForm extends Component {
         this.setState(this.getStateFromProps(this.props))
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.inputElementTypes = this.getInputElementTypes(nextProps.elementTypes)
-        this.setState(this.getStateFromProps(nextProps))
+    componentWillReceiveProps({ elementTypes, ...props }, { joifulReactForms: { JoifulInput } }) {
+        this.inputElementTypes = this.getInputElementTypes(
+            elementTypes || (JoifulInput && JoifulInput.types) || {}
+        )
+        this.setState(this.getStateFromProps(props))
     }
 
     getInputElementTypes(elementTypes) {


### PR DESCRIPTION
with this, a user would be able to define element types globally.

``` javascript
static childContextTypes = {
    joifulReactForms: PropTypes.object
};

getChildContext() {
    return {
        joifulReactForms: {
            JoifulInput: {
                types: {
                    text: ...,
                    select: ...,
                    dateTime: ...,
                    ...
                }
            }
        }
    }
}
```
