### PR TITLE
Renamed passed property "fieldName" to "name"

### DIFF
--- a/src/DefaultElements/DefaultInputGroup.js
+++ b/src/DefaultElements/DefaultInputGroup.js
@@ -44,7 +44,7 @@ export default class JoifulDefaultInputGroup extends Component {
           return (
             <Input
               elementType={elementType}
-              fieldName={fieldSchema._joinedMetaData.name}
+              name={fieldSchema._joinedMetaData.name}
               key={key}
             />
           )


### PR DESCRIPTION
Otherwise the input field won't have a name and the most simple example would not work.
